### PR TITLE
Add namespace to watch() inside on()

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -136,7 +136,7 @@ on <- function(
     )
   )
   observeEvent(
-    substitute(watch(name)),
+    substitute(gargoyle::watch(name)),
     {
       substitute(expr)
     },

--- a/R/funs.R
+++ b/R/funs.R
@@ -1,4 +1,4 @@
-#' Initiate, triger, event
+#' Initiate, trigger, event
 #'
 #' @param name,... The name(s) of the events
 #' @param session The shiny session object


### PR DESCRIPTION
# The context

The definition of the `on()` function assumes that the `watch()` function is also loaded in the current session. This is not an issue if the entire `gargoyle` package is called with `library(gargoyle)` or an equivalent. However, if a user uses `golem` for example and imports exactly the needed functions from the package, this becomes problematic. The simple example below illustrates this fact:

```
library(shiny)

ui <- fluidPage(
  numericInput(inputId = "numIn", label = "Number", value = 0, min = 0, max = 10, step = 1)
)

server <- function(input, output, session){
  
  gargoyle::init("print")
  
  observeEvent(input$numIn, {
    if(input$numIn >= 5)  gargoyle::trigger("print")
  })
  
  gargoyle::on("print", {
    print(paste0("5 or above"))
  })
}

shinyApp(ui = ui, server = server)
```

The app is unable to launch due to the following error:

```
Warning: Error in watch: could not find function "watch"
  [No stack trace available]
```

The problematic line of code is pointed out in Issue #2 

# The solution

In this pull request, `gargoyle`'s namespace was added to the `watch()` function, which entirely solves the issue (as pointed out in issue #2 as well).