### PR TITLE
Minor bugfix and typo in example and man file per #8

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -27,7 +27,7 @@
 #'   server <- function(input, output, session){
 #'
 #'     # Initiating the flags
-#'     init( "plop", "pouet", "poum")
+#'     init("airquality", "iris", "renderiris")
 #'
 #'     # Creating a new env to store values, instead of
 #'     # a reactive structure

--- a/man/Event.Rd
+++ b/man/Event.Rd
@@ -4,7 +4,7 @@
 \alias{init}
 \alias{trigger}
 \alias{watch}
-\title{Initiate, triger, event}
+\title{Initiate, trigger, event}
 \usage{
 init(..., session = getDefaultReactiveDomain())
 
@@ -22,7 +22,7 @@ The `session` object invisibly.
 These functions are mainly used for side-effects.
 }
 \description{
-Initiate, triger, event
+Initiate, trigger, event
 }
 \examples{
 if (interactive()){
@@ -41,7 +41,7 @@ if (interactive()){
   server <- function(input, output, session){
 
     # Initiating the flags
-    init( "plop", "pouet", "poum")
+    init("airquality", "iris", "renderiris")
 
     # Creating a new env to store values, instead of
     # a reactive structure


### PR DESCRIPTION
Fix #8

- change flag names from to "plop" "pouet" and "poum" to "airquality", "iris", "renderiris"
- fix `Triger` to `Trigger` in man/Event
- update doc with new flag names in man/Event