### PR TITLE
Improve docs

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -56,7 +56,7 @@ covr::package_coverage()
 ### What the heck?
 
 `{gargoyle}` is a package that provides wrappers around `{shiny}` to turn your app into and event-based application instead of a full reactive app.
-The framework is centered around a `listen` & `trigger` mechanism.
+The framework is centered around a `watch` & `trigger` mechanism.
 
 It works with classical UI, and just needs tweaking the server side of your app.
 
@@ -69,8 +69,8 @@ That's where `{gargoyle}` comes into play: it provides an event based paradigm f
 
 ### For whom?
 
-If you're just building small `{shiny}` apps, you're probably good with `{shiny}` default reactive behavior.
-But if ever you've struggled with reactivity on more bigger apps, you might find `{gargoyle}` useful.
+If you're just building small `{shiny}` apps you're probably good with `{shiny}` default reactive behavior.
+But if ever you've struggled with reactivity in larger apps you might find `{gargoyle}` useful.
 
 ### The trade-off
 
@@ -81,9 +81,9 @@ I believe this is for the best if you're working on a big project.
 
 `{gargoyle}` has:
 
-+ `init`, `listen` & `trigger`, which allow to initiate, listen on, and trigger an event
++ `init`, `watch` & `trigger`, which allow to initiate, watch, and trigger an event
 
-+ `on`, that runs the `expr` when the event in triggered
++ `on`, that runs the `expr` when the event is triggered
 
 `gargoyle::trigger()` can print messages to the console using `options("gargoyle.talkative" = TRUE)`.
 
@@ -111,7 +111,7 @@ server <- function(input, output, session){
   # a reactive structure
   z <- new.env()
 
-  observeEvent( input$y , {
+  observeEvent(input$y , {
     z$v <- mtcars
     # Triggering the flag
     trigger("airquality")

--- a/README.Rmd
+++ b/README.Rmd
@@ -65,17 +65,18 @@ Because, you know, the good thing about reactivity is that when something moves 
 But the bad thing about reactivity is that when something moves somewhere, it's updated everywhere.
 So it does work pretty well on small apps, but can get very complicated on bigger apps, and can quickly get out of hands.
 
-That's where `{gargoyle}` comes into play: it provides an event based paradigm for building your apps, so that things happen under a control flow.
+That's where `{gargoyle}` comes into play: it provides an event based paradigm for building your apps, so that reactivity happens under a controlled flow.
 
 ### For whom?
 
 If you're just building small `{shiny}` apps you're probably good with `{shiny}` default reactive behavior.
-But if ever you've struggled with reactivity in larger apps you might find `{gargoyle}` useful.
+But if ever you've struggled with reactivity in larger apps you might find `{gargoyle}` useful: only invalidate contexts when you want and make the general flow of your app more predictable!
 
 ### The trade-off
 
 `{gargoyle}` will be more verbose and will demand more work upfront to make things happen.
-I believe this is for the best if you're working on a big project.
+I believe this is for the best if you're working on a big project: from the very beginning 
+it forces the user to think more carefully about app design and the reactive flow.
 
 ## Design pattern
 


### PR DESCRIPTION
Two things:

- fix typos/unclear formulation
- I think (as a user, that was the case for me) the `README` of the package could be a bit more encouraging; I only realized the usefullness of `gargoyle` when reading the shiny production grade book, but less so from the package description; hence I'd add a more motivational/encouraging `README`