### PR TITLE
fix: pass argument session down to watch()

### DIFF
--- a/R/funs.R
+++ b/R/funs.R
@@ -136,7 +136,7 @@ on <- function(
     )
   )
   observeEvent(
-    substitute(gargoyle::watch(name)),
+    substitute(gargoyle::watch(name, session = session)),
     {
       substitute(expr)
     },


### PR DESCRIPTION
Fix #17 

Could not to get reprexes working with these shiny reactive console things... 

so here is the output from my console copy pasted:

```r
library(shiny)
library(gargoyle)
 
shiny::reactiveConsole(TRUE)
s <- shiny::MockShinySession$new()
 
init("pif", session = s)
#> [[1]]
#> reactiveVal: [1] "0" 

test_for_on_function <- on(
     "pif",
     {
         cat("TEST fails")
     },
     session = s
)
test_for_on_function$.func()
#> TEST fails
shiny::reactiveConsole(FALSE)
```

The message "TEST fails" prints correctly compared to the issue where the error is produced.